### PR TITLE
Alter mismatch evlauation and add bedGraph output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,8 +194,11 @@ add_custom_target(
         #        OUTPUT ${PROJECT_SOURCE_DIR}/external/htslib/config.h # //TODO: at build time ${htslib_SOURCE_DIR} is not actually populated!! is an empty string
         WORKING_DIRECTORY ${HTS_DIR}
         COMMAND pwd
+        #COMMAND curl -o config.guess https://git.savannah.gnu.org/cgit/config.git/plain/config.guess
+        #COMMAND curl -o config.sub https://git.savannah.gnu.org/cgit/config.git/plain/config.sub
         COMMAND autoconf
         COMMAND autoheader
+        # added this will need to be resolved for work anywhere else
         COMMAND ./configure --disable-lzma --disable-libcurl --disable-bz2 --disable-s3 --disable-gcs --without-libdeflate --disable-plugins
         COMMAND $(MAKE) prefix=${CMAKE_SOURCE_DIR}/external/htslib/ install
 )

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
     wget \
     gcc \ 
     samtools \
+    bedtools \
     build-essential \
     bzip2 \
     git \

--- a/inc/Bam.hpp
+++ b/inc/Bam.hpp
@@ -34,6 +34,7 @@ public:
         int64_t nonmatches;
         int64_t inferred_length;
         double identity;
+        int64_t mapq;
     };
 
 

--- a/inc/Bam.hpp
+++ b/inc/Bam.hpp
@@ -32,6 +32,8 @@ public:
         int64_t end;
         int64_t matches;
         int64_t nonmatches;
+        int64_t indels;
+        int64_t indel_length;
         int64_t inferred_length;
         double identity;
         int64_t mapq;

--- a/inc/Bam.hpp
+++ b/inc/Bam.hpp
@@ -25,6 +25,18 @@ class Bam {
     bam1_t* alignment;
 
 public:
+    // Define AlignmentSummary struct
+    struct AlignmentSummary {
+        string ref_name;
+        int64_t start;
+        int64_t end;
+        int64_t matches;
+        int64_t nonmatches;
+        int64_t inferred_length;
+        double identity;
+    };
+
+
     Bam(path bam_path);
     ~Bam();
     void for_alignment_in_bam(const function<void(const string& ref_name, const string& query_name, int32_t query_length, uint8_t map_quality, uint16_t flag)>& f);
@@ -34,6 +46,9 @@ public:
     static bool is_not_primary(uint16_t flag);
     static bool is_primary(uint16_t flag);
     static bool is_supplementary(uint16_t flag);
+
+    // Helper function to generate unique key for an alignment
+    string createUniqueKey(const string& ref_name, int start, int end, int matches, int nonmatches, string qname);
 };
 
 }

--- a/inc/Sam.hpp
+++ b/inc/Sam.hpp
@@ -28,9 +28,10 @@ public:
     int32_t query_length;
     uint16_t flag;
     uint8_t mapq;
+    int32_t start_pos;
 
     SamElement();
-    SamElement(string& read_name, string& ref_name, uint16_t flag, uint8_t mapq);
+    SamElement(string& read_name, string& ref_name, uint16_t flag, uint8_t mapq, int32_t start_pos);
     bool is_first_mate() const;
     bool is_second_mate() const;
     bool is_not_primary() const;

--- a/src/Bam.cpp
+++ b/src/Bam.cpp
@@ -2,11 +2,13 @@
 
 #include <stdexcept>
 #include <iostream>
+#include <sstream>
 #include <vector>
 
 using std::runtime_error;
 using std::vector;
 using std::cerr;
+using std::string;
 
 
 namespace gfase{
@@ -66,6 +68,7 @@ void Bam::for_alignment_in_bam(bool get_cigar, const function<void(SamElement& a
 
         e.mapq = alignment->core.qual;
         e.flag = alignment->core.flag;
+        e.start_pos = alignment->core.pos;
 
         if (get_cigar) {
             auto n_cigar = alignment->core.n_cigar;
@@ -109,6 +112,13 @@ bool Bam::is_primary(uint16_t flag){
 
 bool Bam::is_supplementary(uint16_t flag){
     return (uint16_t(flag) >> 11) & uint16_t(1);
+}
+
+string Bam::createUniqueKey(const string& ref_name, int start, int end, int matches, int nonmatches, string qname) {
+    std::stringstream oss;
+    oss << qname << "_" << ref_name << "_" << start << "_" << end << "_"
+        << matches << "_" << nonmatches;
+    return oss.str();
 }
 
 

--- a/src/Sam.cpp
+++ b/src/Sam.cpp
@@ -16,11 +16,12 @@ using std::cerr;
 namespace gfase {
 
 
-SamElement::SamElement(string& read_name, string& ref_name, uint16_t flag, uint8_t mapq) :
+SamElement::SamElement(string& read_name, string& ref_name, uint16_t flag, uint8_t mapq, int32_t start_pos) :
         query_name(read_name),
         ref_name(ref_name),
         flag(flag),
-        mapq(mapq)
+        mapq(mapq),
+        start_pos(start_pos)
 {}
 
 
@@ -111,6 +112,7 @@ void for_element_in_sam_file(path sam_path, const function<void(SamElement& e)>&
     string read_name;
     string flag_token;
     string ref_name;
+    string start_pos;
     string mapq_token;
 
     char header_delimiter = '@';
@@ -126,7 +128,7 @@ void for_element_in_sam_file(path sam_path, const function<void(SamElement& e)>&
         if (c == '\n'){
             n_delimiters = 0;
 
-            SamElement e(read_name, ref_name, int16_t(stoi(flag_token)), int8_t(stoi(mapq_token)));
+            SamElement e(read_name, ref_name, int16_t(stoi(flag_token)), int8_t(stoi(mapq_token)), int32_t(stoi(start_pos)));
 
             f(e);
 
@@ -149,6 +151,9 @@ void for_element_in_sam_file(path sam_path, const function<void(SamElement& e)>&
             }
             else if (n_delimiters == 2){
                 ref_name += c;
+            }
+            else if (n_delimiters == 3){
+                start_pos += c;
             }
             else if (n_delimiters == 4){
                 mapq_token += c;

--- a/src/executable/wam.cpp
+++ b/src/executable/wam.cpp
@@ -59,7 +59,9 @@ template<class T1, class T2> void write_sorted_distribution_to_file(const unorde
 void sort_bedgraph(const std::string& input_file, const std::string& output_file) {
 
     if (std::system("command -v bedtools > /dev/null 2>&1") != 0) {
-        std::cerr << "Error: bedtools is not installed or not in PATH." << std::endl;
+        std::cerr << "WARNING: bedtools is not installed or not in PATH." << std::endl;
+        std::cerr << "WARNING: alignment_summary.tsv should be sorted with command: bedtools sort -i alignment_summary.tsv > alignment_summary.sorted.bed" << std::endl;
+        return;
     }
     // Make the bedtools sort command
     std::string command = "bedtools sort -i " + input_file + " > " + output_file;
@@ -69,7 +71,9 @@ void sort_bedgraph(const std::string& input_file, const std::string& output_file
 
     // Check the return code
     if (ret_code != 0) {
-        std::cerr << "Error: bedtools sort failed with return code " << ret_code << std::endl;
+        std::cerr << "WARNING: bed file was not sorted " << ret_code << std::endl;
+        std::cerr << "WARNING: alignment_summary.tsv should be sorted with command: bedtools sort -i alignment_summary.tsv > alignment_summary.sorted.bed" << std::endl;
+        return;
     } else {
         std::cout << "Successfully sorted the BEDGraph file: " << output_file << std::endl;
     }
@@ -114,6 +118,8 @@ void write_sorted_alignment_summary_to_file(const unordered_map<string, Alignmen
     }
     file.close();
 
+    std::cout << "Successfully wrote alignment summary file: " << output_path << std::endl;
+    std::cout << "Now sorting alignment summary into bedgraph." << std::endl;
     sort_bedgraph(output_path, output_path.string()+".sorted.bed");
 
 }

--- a/src/executable/wam.cpp
+++ b/src/executable/wam.cpp
@@ -91,7 +91,7 @@ void write_sorted_alignment_summary_to_file(const unordered_map<string, Alignmen
     }
 
     // write the header to the csv
-    file << "#chr" << "\tstart_pos" << "\tend_pos" << "\tidentity" << "\tmatches" << "\tnonmatches"
+    file << "#chr" << "\tstart_pos" << "\tend_pos" << "\tidentity" << "\tmatches" << "\tnonmatches" << "\tindels" << "\tindel_total_length"
                                                                 << "\tinferred_len" << "\tmapq" << "\talignmentName" << "\n";
       
     // add bedGraph header 
@@ -106,6 +106,8 @@ void write_sorted_alignment_summary_to_file(const unordered_map<string, Alignmen
              << summary.identity << '\t'
              << summary.matches << '\t'
              << summary.nonmatches << '\t'
+             << summary.indels << '\t'
+             << summary.indel_length << '\t'
              << summary.inferred_length << '\t'
              << summary.mapq << '\t'
              << key << '\n';
@@ -211,7 +213,7 @@ void get_identity_from_bam(path bam_path, path output_dir){
         // make a unique name for each alignment and insert the summary data into the map
         string uniqueName = bam_reader.createUniqueKey(e.ref_name, e.start_pos,
                                                          alignment_end, matches, nonmatches, e.query_name);
-        AlignmentSummary summary = {e.ref_name, e.start_pos, alignment_end, matches, nonmatches, inferred_query_length, identity, e.mapq};
+        AlignmentSummary summary = {e.ref_name, e.start_pos, alignment_end, matches, nonmatches, indels, indel_total_length, inferred_query_length, identity, e.mapq};
         alignment_summaries[uniqueName] = summary;
 
 

--- a/wdl/tasks.wdl
+++ b/wdl/tasks.wdl
@@ -32,7 +32,7 @@ task runWambam {
         memory: memSizeGB + " GB"
         cpu: 1
         disks: "local-disk " + diskSizeGB + " SSD"
-        docker: "quay.io/jmonlong/wambam:latest"
+        docker: "meredith705/wambam:latest"
         preemptible: 1
     }
 }

--- a/wdl/tasks.wdl
+++ b/wdl/tasks.wdl
@@ -26,6 +26,7 @@ task runWambam {
 	output {
 		File identityDist = "wambam_results/identity_distribution.csv"
 		File lengthDist = "wambam_results/length_distribution.csv"
+        File alignedSummary = "wambam_results/alignment_summary.tsv"
 	}
 
     runtime {

--- a/wdl/tasks.wdl
+++ b/wdl/tasks.wdl
@@ -27,6 +27,7 @@ task runWambam {
 		File identityDist = "wambam_results/identity_distribution.csv"
 		File lengthDist = "wambam_results/length_distribution.csv"
         File alignedSummary = "wambam_results/alignment_summary.tsv"
+        File bedGraph = "wambam_results/alignment_summary.tsv.sorted.bed"
 	}
 
     runtime {

--- a/wdl/workflow.wdl
+++ b/wdl/workflow.wdl
@@ -46,6 +46,7 @@ workflow wambam {
     output {
         File identity_dist_csv = runWambam.identityDist
         File length_dist_csv = runWambam.lengthDist
+        File alignedSummary_tsv = runWambam.alignedSummary
         File graph_pdf = makeWambamGraphs.graphsPdf
         File summary_csv = makeWambamGraphs.summaryCsv
         File? bam = runMinimap2.bam

--- a/wdl/workflow.wdl
+++ b/wdl/workflow.wdl
@@ -47,6 +47,7 @@ workflow wambam {
         File identity_dist_csv = runWambam.identityDist
         File length_dist_csv = runWambam.lengthDist
         File alignedSummary_tsv = runWambam.alignedSummary
+        File bedGraph_bed = runWambam.bedGraph
         File graph_pdf = makeWambamGraphs.graphsPdf
         File summary_csv = makeWambamGraphs.summaryCsv
         File? bam = runMinimap2.bam


### PR DESCRIPTION
Adding contig/query length estimates for filtering by contig length.
Altering mismatch calculation to only count INDELs < 50bps as mismatches
Add bedGraph and alignment summary file output describing each alignment with a unique alignment identifier.